### PR TITLE
Making it work on Fedora and Python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,16 @@ all: clewarecontrol
 clewarecontrol: $(OBJS)
 	$(CXX) $(OBJS) $(LDFLAGS) -o clewarecontrol
 
-cleware_python:
-	swig -c++ -python cleware.i
+cleware_python: pyswig
 	python setup.py build_ext --inplace
-	./install-lib.py
+	python install-lib.py
+
+cleware_python3: pyswig
+	python3 setup.py build_ext --inplace
+	python3 install-lib.py
+
+pyswig:
+	swig -c++ -python cleware.i
 
 cleware_perl:
 	swig -c++ -perl5 cleware.i

--- a/install-lib.py
+++ b/install-lib.py
@@ -1,5 +1,3 @@
-#! /usr/bin/python
-
 import sys
 import shutil
 
@@ -8,12 +6,12 @@ for p in sys.path:
 	pos = p.find('/local/', 0)
 	if pos >= 0:
 		found=1
-		print 'Installing into %s' % (p)
+		print('Installing into %s' % (p))
 		shutil.copy('_cleware.so', p)
 		shutil.copy('cleware.py', p)
 
 if found == 0:
-	print 'Could not find a location to copy the library into.'
-	print 'You may want to install cleware.py and _cleware.so into the appropriate directory.'
+	print('Could not find a location to copy the library into.')
+	print('You may want to install cleware.py and _cleware.so into the appropriate directory.')
 else:
-	print 'Finished.'
+	print('Finished.')

--- a/readme-python.txt
+++ b/readme-python.txt
@@ -1,9 +1,10 @@
 To build the Python code:
  - install the Python development package
    on Debian this is called e.g. "python2.7-dev" or "python3.2-dev"
+   on Fedora "python-devel" for python 2 or "python3-devel" for python 3
 
  - install the swig package
-   on Debian this is valled "swig"
+   on Debian and Fedora this is called "swig"
 
  - run:
 	make cleware_python

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,8 @@
 build instructions
 ------------------
 Required libraries:
-	libhidapi-dev
+        libhidapi-dev (Debian)
+        hidapi-devel (Fedora)
 
 Since version 4.0 clewarecontrol uses this library to abstract the
 interfacing with the kernel. That way it may work on other OSes and new(er)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
 from distutils.core import setup, Extension
-
-cleware_module = Extension('_cleware',
-                           sources=['cleware_wrap.cxx', 'USBaccessBasic.cpp', 'USBaccess.cpp'],
-                           )
+srcs = ['cleware_wrap.cxx', 'USBaccessBasic.cpp', 'USBaccess.cpp']
+libs = ['hidapi-hidraw']
+cleware_module = Extension('_cleware', sources=srcs, libraries=libs)
 
 setup (name = 'cleware',
        version = '2.3',


### PR DESCRIPTION
There are 3 sets of changes included here, setup.py not linking to the host system libraries, for making it work in python3 and for making it work in Fedora. I've tested them in the following way:

    me@machine:clewarecontrol[on-fedora]$ sudo python3
    Python 3.4.3 (default, Jul 11 2016, 11:30:44) 
    [GCC 5.3.1 20160406 (Red Hat 5.3.1-6)] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from cleware import CUSBaccess as CW
    >>> cw = CW()
    >>> n = cw.OpenCleware()
    >>> cw.GetSerialNumber(0)
    710232
    >>> cw.GetSwitch(0,cw.SWITCH_7)
    1
    >>> cw.GetSwitch(0,cw.SWITCH_0)
    0
    >>> cw.SetSwitch(0,cw.SWITCH_2,1)
    1