### PR TITLE
Fix Python module installation. Closes: #21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *.o
 clewarecontrol
+*~
+_cleware.so
+build
+cleware.py
+cleware.pyc
+cleware_wrap.cxx

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DEBUG=-g -W -pedantic #-pg #-fprofile-arcs
 LDFLAGS+=-L/usr/local/hidapi.git/lib -lhidapi-libusb
 CXXFLAGS+=-O3 -Wall -DVERSION=\"$(VERSION)\" $(DEBUG) -I/usr/local/hidapi.git/include
 CFLAGS+=$(CXXFLAGS)
+SETUPPY_INSTALLTO=--user
 
 OBJS=main.o USBaccess.o USBaccessBasic.o error.o
 TRANSLATIONS=nl.mo
@@ -17,7 +18,7 @@ clewarecontrol: $(OBJS) $(TRANSLATIONS)
 	$(CXX) $(OBJS) $(LDFLAGS) -o clewarecontrol
 
 cleware_python cleware_python3:  pyswig
-	$(subst cleware_,,$@) setup.py install
+	$(subst cleware_,,$@) setup.py install $(SETUPPY_INSTALLTO)
 
 pyswig:
 	swig -c++ -python cleware.i


### PR DESCRIPTION
* Install to user's .local by default
* Ignore editor backups and build artifacts

Signed-off-by: Al Nikolov <alexey.nikolov@etteplan.com>